### PR TITLE
Get best send delay in a simple way

### DIFF
--- a/tps-bench/specs/dev.toml
+++ b/tps-bench/specs/dev.toml
@@ -18,10 +18,10 @@ block_time = 1000
 
 # Benchmark
 ## - transaction_type :: "In1Out1" | "In2Out2" | "In3Out3"
-## - send_delay :: millisecond
+## - send_delay :: microseconds
 [[benchmarks]]
 transaction_type = "In2Out2"
-send_delay = 10
+send_delay = 10000
 [[benchmarks]]
 transaction_type = "In2Out2"
-send_delay = 1
+send_delay = 1000

--- a/tps-bench/specs/staging.toml
+++ b/tps-bench/specs/staging.toml
@@ -17,10 +17,10 @@ confirmation_blocks = 6
 
 # Benchmark
 ## - transaction_type :: "In1Out1" | "In2Out2" | "In3Out3"
-## - send_delay :: millisecond
+## - send_delay :: microsecond
 [[benchmarks]]
 transaction_type = "In2Out2"
-send_delay = 10
+send_delay = 10000
 [[benchmarks]]
 transaction_type = "In2Out2"
-send_delay = 1
+send_delay = 1000

--- a/tps-bench/src/benchmark.rs
+++ b/tps-bench/src/benchmark.rs
@@ -18,8 +18,8 @@ use std::time::{Duration, Instant};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct BenchmarkConfig {
-    transaction_type: TransactionType,
-    send_delay: u64, // micros
+    pub transaction_type: TransactionType,
+    pub send_delay: u64, // micros
 }
 
 impl BenchmarkConfig {
@@ -29,7 +29,7 @@ impl BenchmarkConfig {
         sender: &Account,
         recipient: &Account,
         sender_utxo_rx: &Receiver<UTXO>,
-    ) {
+    ) -> u64 {
         crate::net_monitor::wait_network_txpool_empty(&net);
 
         let current_confirmed_tip = net.get_confirmed_tip_number();
@@ -111,9 +111,10 @@ impl BenchmarkConfig {
                 });
 
                 info!("[BENCHMARK RESULT] {}", result,);
-                break;
+                return result["metrics"]["tps"].as_u64().expect("get tps");
             }
         }
+        return 0
     }
 }
 

--- a/tps-bench/src/benchmark.rs
+++ b/tps-bench/src/benchmark.rs
@@ -19,7 +19,7 @@ use std::time::{Duration, Instant};
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct BenchmarkConfig {
     transaction_type: TransactionType,
-    send_delay: u64, // millis
+    send_delay: u64, // micros
 }
 
 impl BenchmarkConfig {
@@ -95,7 +95,7 @@ impl BenchmarkConfig {
             }
 
             // Sleep every time sending transaction.
-            sleep(Duration::from_millis(self.send_delay));
+            sleep(Duration::from_micros(self.send_delay));
 
             if let Ok(metrics) = net_notifier.try_recv() {
                 let result = json!({

--- a/tps-bench/src/command.rs
+++ b/tps-bench/src/command.rs
@@ -6,7 +6,7 @@ pub const BENCH_SUBCOMMAND: &str = "bench";
 #[derive(Debug, Clone)]
 pub enum CommandLine {
     MineMode(Config, u64 /* blocks */),
-    BenchMode(Config, bool),
+    BenchMode(Config),
 }
 
 pub fn commandline() -> CommandLine {
@@ -39,9 +39,6 @@ pub fn commandline() -> CommandLine {
                     clap::Arg::from_usage("--seconds <NUMBER> 'the seconds to bench, default and 0 represent forever'")
                         .required(false)
                         .validator(|s| s.parse::<u64>().map(|_| ()).map_err(|err| err.to_string())),
-                )
-                .arg(clap::Arg::from_usage("--get_best_send_delay 'get best send delay'")
-                        .required(false),
                 ),
         )
         .get_matches();
@@ -93,8 +90,7 @@ pub fn commandline() -> CommandLine {
                 .expect("clap arg option `validator` checked");
             let seconds = if seconds == 0 { None } else { Some(seconds) };
             let config = Config::new(spec, rpc_urls, seconds);
-            let get_best_send_delay = !matches.is_present("get_best_send_delay");
-            CommandLine::BenchMode(config, get_best_send_delay)
+            CommandLine::BenchMode(config)
         }
         (subcommand, options) => {
             prompt_and_exit!(

--- a/tps-bench/src/command.rs
+++ b/tps-bench/src/command.rs
@@ -6,7 +6,7 @@ pub const BENCH_SUBCOMMAND: &str = "bench";
 #[derive(Debug, Clone)]
 pub enum CommandLine {
     MineMode(Config, u64 /* blocks */),
-    BenchMode(Config),
+    BenchMode(Config, bool),
 }
 
 pub fn commandline() -> CommandLine {
@@ -39,6 +39,9 @@ pub fn commandline() -> CommandLine {
                     clap::Arg::from_usage("--seconds <NUMBER> 'the seconds to bench, default and 0 represent forever'")
                         .required(false)
                         .validator(|s| s.parse::<u64>().map(|_| ()).map_err(|err| err.to_string())),
+                )
+                .arg(clap::Arg::from_usage("--get_best_send_delay 'get best send delay'")
+                        .required(false),
                 ),
         )
         .get_matches();
@@ -90,7 +93,8 @@ pub fn commandline() -> CommandLine {
                 .expect("clap arg option `validator` checked");
             let seconds = if seconds == 0 { None } else { Some(seconds) };
             let config = Config::new(spec, rpc_urls, seconds);
-            CommandLine::BenchMode(config)
+            let get_best_send_delay = !matches.is_present("get_best_send_delay");
+            CommandLine::BenchMode(config, get_best_send_delay)
         }
         (subcommand, options) => {
             prompt_and_exit!(

--- a/tps-bench/src/main.rs
+++ b/tps-bench/src/main.rs
@@ -19,6 +19,7 @@ use crate::miner::Miner;
 use crate::net::Net;
 use crate::rpc::Jsonrpc;
 use crate::threads::{spawn_miner, spawn_pull_utxos, spawn_transfer_utxos};
+use crate::benchmark::BenchmarkConfig;
 
 pub mod benchmark;
 pub mod global;
@@ -47,7 +48,7 @@ fn main() {
             let miner = Miner::new(miner_config, rpc_urls);
             miner.generate_blocks(blocks);
         }
-        CommandLine::BenchMode(config) => {
+        CommandLine::BenchMode(config, get_best_send_delay) => {
             info!("\nTPSBench start with configuration: {}", json!(config));
             init_logger(&config);
             init_metrics_recorder(&config);
@@ -74,8 +75,54 @@ fn main() {
 
             // Benchmark
             let net = Net::connect_all(config.rpc_urls());
-            for benchmark in config.benchmarks.iter() {
-                benchmark.bench(&net, &bencher, &bencher, &bencher_utxo_r);
+            if !get_best_send_delay {
+                for benchmark in config.benchmarks.iter() {
+                    benchmark.bench(&net, &bencher, &bencher, &bencher_utxo_r);
+                }
+            } else {
+                let transaction_type = config.benchmarks[0].transaction_type;
+                let mut lowest_send_delay = 10;
+                let mut highest_send_delay = 10000;
+                for benchmark in config.benchmarks.iter() {
+                    if benchmark.send_delay > highest_send_delay {
+                        highest_send_delay = benchmark.send_delay;
+                    } else if benchmark.send_delay < lowest_send_delay {
+                        lowest_send_delay = benchmark.send_delay;
+                    }
+                }
+                let low = BenchmarkConfig{
+                    transaction_type: transaction_type,
+                    send_delay: lowest_send_delay,
+                };
+                let high = BenchmarkConfig{
+                    transaction_type: transaction_type,
+                    send_delay: highest_send_delay,
+                };
+                let mut low_tps = low.bench(&net, &bencher, &bencher, &bencher_utxo_r);
+                let mut high_tps = high.bench(&net, &bencher, &bencher, &bencher_utxo_r);
+                let mut test = [low, high];
+                println!("send_delay: {}, tps: {}", lowest_send_delay, low_tps);
+                println!("send delay: {}, tps: {}", highest_send_delay, high_tps);
+                while test[0].send_delay < test[1].send_delay - 1 {
+                    let mid = BenchmarkConfig{
+                        transaction_type: transaction_type,
+                        send_delay: (test[0].send_delay + test[1].send_delay) / 2,
+                    };
+                    let mid_tps = mid.bench(&net, &bencher, &bencher, &bencher_utxo_r);
+                    println!("send_dealy: {}, tps: {}", mid.send_delay, mid_tps);
+                    if low_tps < high_tps {
+                        test[0] = mid;
+                        low_tps = mid_tps;
+                    } else {
+                        test[1] = mid;
+                        high_tps = mid_tps;
+                    }
+                }
+                if low_tps < high_tps {
+                    println!("\nbest send delay: {}, tps: {}", test[1].send_delay, high_tps);
+                } else {
+                    println!("\nbest send delay: {}, tps: {}", test[0].send_delay, low_tps);
+                }
             }
         }
     }


### PR DESCRIPTION
实现了一个比较简单粗暴的方法来获取可以达到最大 tps 的 send_delay，这里简化了几个条件：

1. 简单的认为 tps 与 send_delay 的关系为单调递增或单调递减函数；
2. 对于某一个 send_delay 只计算一次 tps；
3. 简化了其他变量，如 transaction_type 固定为配置文件中的某一个项；