### PR TITLE
feat: add nodes count into tps-bench metrics

### DIFF
--- a/tps-bench/src/config.rs
+++ b/tps-bench/src/config.rs
@@ -42,7 +42,7 @@ pub enum TransactionType {
     In3Out3,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, Ord, PartialOrd, PartialEq)]
 pub struct Url(#[serde(with = "url_serde")] pub url::Url);
 
 impl Deref for Config {
@@ -53,7 +53,9 @@ impl Deref for Config {
 }
 
 impl Config {
-    pub fn new(spec: Spec, rpc_urls: Vec<Url>, seconds: Option<u64>) -> Self {
+    pub fn new(spec: Spec, mut rpc_urls: Vec<Url>, seconds: Option<u64>) -> Self {
+        rpc_urls.sort();
+        rpc_urls.dedup();
         Self {
             spec,
             rpc_urls,

--- a/tps-bench/src/net.rs
+++ b/tps-bench/src/net.rs
@@ -81,4 +81,12 @@ impl Net {
         };
         None
     }
+
+    pub fn get_network_nodes(&self) -> u64 {
+        self.endpoints[0].get_peers().len() as u64 + 1 as u64
+    }
+
+    pub fn get_bench_nodes(&self) -> u64 {
+        self.endpoints.len() as u64
+    }
 }


### PR DESCRIPTION
Add two metrics:
- network_nodes: total nodes in the target network
- bench_nodes: nodes used for running tps-bench, which also means nodes from command args `--rpc-urls`