### PR TITLE
feat: update calculate tps method

### DIFF
--- a/tps-bench/specs/dev.toml
+++ b/tps-bench/specs/dev.toml
@@ -5,7 +5,7 @@ data_dir = "tpsbench"
 bencher_private_key = "8c296482b9b763e8be974058272f377462f2975b94454dabb112de0f135e2064"
 
 # Miner will generate blocks until capacity is enough for benching
-ensure_matured_capacity_greater_than = 100000000
+ensure_matured_capacity_greater_than = 10000000000000
 
 # Network Params
 ## - consensus_cellbase_maturity TODO: Add RPC get_consensus_params

--- a/tps-bench/specs/staging.toml
+++ b/tps-bench/specs/staging.toml
@@ -5,7 +5,7 @@ data_dir = "tpsbench"
 bencher_private_key = "8c296482b9b763e8be974058272f377462f2975b94454dabb112de0f135e2064"
 
 # Miner will generate blocks until capacity is enough for benching
-ensure_matured_capacity_greater_than = 100000000
+ensure_matured_capacity_greater_than = 10000000000000
 
 # Network Params
 ## - consensus_cellbase_maturity TODO: Add RPC get_consensus_params

--- a/tps-bench/src/main.rs
+++ b/tps-bench/src/main.rs
@@ -89,12 +89,8 @@ fn main() {
                 transaction_type: TransactionType::In2Out2,
                 send_delay: 0,
             };
-            let (best_send_delay, best_tps) =
-                benchmark.find_best_bench(&net, &bencher, &bencher, &bencher_utxo_r);
-            info!(
-                "Best send_delay: {}, best tps: {}",
-                best_send_delay, best_tps
-            );
+            let best_tps = benchmark.find_best_bench(&net, &bencher, &bencher, &bencher_utxo_r);
+            info!("Best TPS: {}", best_tps);
             println!("TPS: {}", best_tps);
         }
     }


### PR DESCRIPTION
Instead of simply using bisection method to find a specify 'send_dealy - TPS' combination, calculate the average of several nearly TPS maybe a better way to find the stable TPS. 

And also, we only want a good enough TPS result, then we don't need the `benchmarks` configuration section anymore, those result have no reference value in this situation.