### PR TITLE
feat: support benchmark specify method to eval

### DIFF
--- a/tps-bench/src/main.rs
+++ b/tps-bench/src/main.rs
@@ -88,6 +88,7 @@ fn main() {
             let benchmark = BenchmarkConfig {
                 transaction_type: TransactionType::In2Out2,
                 send_delay: 0,
+                method_to_eval_net_stable: None,
             };
             let best_tps = benchmark.find_best_bench(&net, &bencher, &bencher, &bencher_utxo_r);
             info!("Best TPS: {}", best_tps);

--- a/tps-bench/src/net_monitor.rs
+++ b/tps-bench/src/net_monitor.rs
@@ -1,4 +1,3 @@
-use crate::global::METHOD_TO_EVAL_NET_STABLE;
 use crate::net::Net;
 use ckb_types::core::BlockView;
 use log::info;
@@ -37,9 +36,8 @@ pub struct Metrics {
     bench_nodes: u64,
 }
 
-pub fn wait_network_stabled(net: &Net) -> Metrics {
-    let method_to_eval_net_stable = *METHOD_TO_EVAL_NET_STABLE.lock().unwrap();
-    match method_to_eval_net_stable {
+pub fn wait_network_stabled(net: &Net, evaluation: MethodToEvalNetStable) -> Metrics {
+    match evaluation {
         MethodToEvalNetStable::RecentBlocktxnsNearly { window, margin } => {
             wait_recent_blocktxns_nearly(net, window, margin)
         }


### PR DESCRIPTION
Every benchmark case can define its own method to evaluate stability, default is the global one.