### PR TITLE
Updated for running tps-bench on release

### DIFF
--- a/tps-bench/specs/release.toml
+++ b/tps-bench/specs/release.toml
@@ -16,7 +16,7 @@ confirmation_blocks = 6
 # choose the method to eval network stable
 # CustomBlocksElapsed => { warmup = xx, window = xx }
 # RecentBlocktxnsNearly => { margin = xx, window = xx } }
-method_to_eval_network_stable = { CustomBlocksElapsed = { warmup = 20, window = 21 } }
+method_to_eval_network_stable = { TimedTask = { duration_time = 86400 } }
 
 # Dummy Miner
 ## - block_time :: millisecond
@@ -27,9 +27,6 @@ block_time = 1000
 # Benchmark
 ## - transaction_type :: "In1Out1" | "In2Out2" | "In3Out3"
 ## - send_delay :: microsecond
-[[benchmarks]]
-transaction_type = "In2Out2"
-send_delay = 10000
 [[benchmarks]]
 transaction_type = "In2Out2"
 send_delay = 1000

--- a/tps-bench/src/command.rs
+++ b/tps-bench/src/command.rs
@@ -2,11 +2,13 @@ use crate::config::{Config, Spec, Url};
 
 pub const MINE_SUBCOMMAND: &str = "mine";
 pub const BENCH_SUBCOMMAND: &str = "bench";
+pub const METRICS_SUBCOMMAND: &str = "metric";
 
 #[derive(Debug, Clone)]
 pub enum CommandLine {
     MineMode(Config, u64 /* blocks */),
-    BenchMode(Config),
+    BenchMode(Config, bool),
+    MetricMode(Vec<Url>),
 }
 
 pub fn commandline() -> CommandLine {
@@ -20,7 +22,7 @@ pub fn commandline() -> CommandLine {
                      tps-bench mine -s dev --rpc-urls http://127.0.0.1:8114 -b 100",
                 )
                 .arg(clap::Arg::from_usage(
-                    "-s, --spec <FILE> 'the spec: staging, dev, or path to spec file'",
+                    "-s, --spec <FILE> 'the spec: staging, dev, release or path to spec file'",
                 ))
                 .arg(
                     clap::Arg::from_usage("--rpc-urls <ENDPOINTS> 'the ckb rpc endpoints'")
@@ -44,8 +46,21 @@ pub fn commandline() -> CommandLine {
                     tps-bench bench -s dev --rpc-urls http://127.0.0.1:8114",
                 )
                 .arg(clap::Arg::from_usage(
-                    "-s, --spec <FILE> 'the spec: staging, dev, or path to spec file'",
+                    "-s, --spec <FILE> 'the spec: staging, dev, release or path to spec file'",
                 ))
+                .arg(
+                    clap::Arg::from_usage("--rpc-urls <ENDPOINTS> 'the ckb rpc endpoints'")
+                        .required(true)
+                        .multiple(true)
+                        .validator(|s| Url::parse(&s).map(|_| ()).map_err(|err| err.to_string())),
+                )
+                .arg(clap::Arg::from_usage(
+                    "[skip-best-tps-caculation] --skip-best-tps-caculation 'run bench with skip best tps caculation'",
+                )),
+        )
+        .subcommand(
+            clap::SubCommand::with_name(METRICS_SUBCOMMAND)
+                .about("Caculate tps metrics in a specify blocks window")
                 .arg(
                     clap::Arg::from_usage("--rpc-urls <ENDPOINTS> 'the ckb rpc endpoints'")
                         .required(true)
@@ -94,8 +109,17 @@ pub fn commandline() -> CommandLine {
                 .expect("clap arg option `required(true)` checked")
                 .map(|str| Url::parse(str).expect("clap arg option `validator` checked"))
                 .collect::<Vec<_>>();
+            let skip_best_tps_caculation = options.is_present("skip-best-tps-caculation");
             let config = Config::new(spec, rpc_urls);
-            CommandLine::BenchMode(config)
+            CommandLine::BenchMode(config, skip_best_tps_caculation)
+        }
+        (METRICS_SUBCOMMAND, Some(options)) => {
+            let rpc_urls = options
+                .values_of("rpc-urls")
+                .expect("clap arg option `required(true)` checked")
+                .map(|str| Url::parse(str).expect("clap arg option `validator` checked"))
+                .collect::<Vec<_>>();
+            CommandLine::MetricMode(rpc_urls)
         }
         (subcommand, options) => {
             prompt_and_exit!(

--- a/tps-bench/src/config.rs
+++ b/tps-bench/src/config.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 
 pub const STAGING_SPEC: &str = include_str!("../specs/staging.toml");
 pub const DEV_SPEC: &str = include_str!("../specs/dev.toml");
+pub const RELEASE_SPEC: &str = include_str!("../specs/release.toml");
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Config {
@@ -73,6 +74,7 @@ impl Spec {
         let spec = match filepath {
             "staging" => toml::from_str(STAGING_SPEC).map_err(|err| err.to_string())?,
             "dev" => toml::from_str(DEV_SPEC).map_err(|err| err.to_string())?,
+            "release" => toml::from_str(RELEASE_SPEC).map_err(|err| err.to_string())?,
             _ => {
                 let content = std::fs::read_to_string(filepath).map_err(|err| err.to_string())?;
                 let spec: Self = toml::from_str(&content).map_err(|err| err.to_string())?;


### PR DESCRIPTION
1. Add an sub-command `metric` for caculating metrics on test chain;
2. Add total trasactions size in metrics;
3. Add argument `--release-mode` under bench sub-command, which doesn't caculate best tps;
4. Add `release.toml` for release bench;